### PR TITLE
feat: improve TypeScript type safety by eliminating most any usage

### DIFF
--- a/packages/core/src/database/electric.ts
+++ b/packages/core/src/database/electric.ts
@@ -73,7 +73,7 @@ export async function createStore(
   }
 
   // Create and return the DatabaseStore instance
-  // biome-ignore lint/suspicious/noExplicitAny: Type assertion needed for Drizzle schema compatibility
+  // biome-ignore lint/suspicious/noExplicitAny: Type assertion needed for Drizzle schema compatibility with exactOptionalPropertyTypes
   return new DatabaseStore(pgLite, sql as any, electric, isEncrypted);
 }
 

--- a/packages/core/src/services/generators/schemas.ts
+++ b/packages/core/src/services/generators/schemas.ts
@@ -9,7 +9,7 @@
  */
 
 import { z } from 'zod';
-import { createTaskSchema } from '../../schemas/task.js';
+import { createTaskSchema, taskSchema } from '../../schemas/task.js';
 
 /**
  * Input data for task generation
@@ -21,7 +21,7 @@ export const generationInputSchema = z.object({
   context: z
     .object({
       /** Existing tasks for context (full Task objects) */
-      existingTasks: z.array(z.any()).optional(),
+      existingTasks: z.array(taskSchema).optional(),
       /** Parent task ID for generated tasks */
       parentTaskId: z.string().optional(),
       /** Additional metadata */
@@ -37,7 +37,7 @@ export const generationInputSchema = z.object({
  */
 export const generationContextSchema = z.object({
   /** Existing tasks for context awareness */
-  existingTasks: z.array(z.any()).optional(),
+  existingTasks: z.array(taskSchema).optional(),
   /** Parent task ID if generating subtasks */
   parentTaskId: z.string().nullable().optional(),
   /** Additional metadata */
@@ -77,7 +77,7 @@ export const llmChainInputSchema = z.object({
   /** Content to analyze */
   content: z.string(),
   /** Existing tasks for context */
-  existingTasks: z.array(z.any()),
+  existingTasks: z.array(taskSchema),
   /** Additional metadata */
   metadata: z.record(z.unknown()),
 });

--- a/packages/mcp/src/handlers/TaskGenerationHandlers.ts
+++ b/packages/mcp/src/handlers/TaskGenerationHandlers.ts
@@ -9,7 +9,7 @@
  */
 
 import type { HandlerContext, MCPHandler } from './types.js';
-import { createPRDTaskGenerator, type GenerationError, createModuleLogger, getCurrentModelConfig } from '@astrolabe/core';
+import { createPRDTaskGenerator, type GenerationError, createModuleLogger, getCurrentModelConfig, type Task } from '@astrolabe/core';
 import { taskToApi } from '@astrolabe/core';
 
 /**
@@ -74,13 +74,13 @@ export class TaskGenerationHandlers implements MCPHandler {
       );
 
       // Load existing tasks for context if requested
-      let existingTasks: any[] = [];
+      let existingTasks: Task[] = [];
       if (params.context?.existingTasks) {
         const taskPromises = params.context.existingTasks.map((id) => 
           this.context.store.getTask(id)
         );
         const tasks = await Promise.all(taskPromises);
-        existingTasks = tasks.filter(Boolean);
+        existingTasks = tasks.filter((task): task is Task => task !== null);
       }
 
       // Generate tasks
@@ -96,10 +96,10 @@ export class TaskGenerationHandlers implements MCPHandler {
         params.context?.parentTaskId ?? null
       );
 
-      // Convert to API format
-      const apiTasks = createTasks.map((task: any) => taskToApi({
+      // Convert to API format by creating complete Task objects with required fields
+      const apiTasks = createTasks.map((task) => taskToApi({
         ...task,
-        id: 'generated-' + Math.random().toString(36).substr(2, 9), // Temporary ID
+        id: 'generated-' + Math.random().toString(36).substring(2, 11), // Temporary ID
         createdAt: new Date(),
         updatedAt: new Date(),
         parentId: task.parentId ?? null,


### PR DESCRIPTION
This PR improves TypeScript type safety by replacing most `any` usage with proper typed schemas and interfaces.

## Changes

- Replace `z.any()` with proper `taskSchema` validation in generation schemas
- Add proper `Task` types and type guards in MCP handlers
- Document necessary type assertion with proper biome-ignore comment
- Improve type safety throughout task generation pipeline
- Ensure full TypeScript compilation and linting compliance

This eliminates most TypeScript `any` usage while maintaining functionality and complying with CLAUDE.md principle #5.

Resolves #4

Generated with [Claude Code](https://claude.ai/code)