### PR TITLE
refactor: cleanup and simplify TaskTree implementation

### DIFF
--- a/packages/cli/source/commands/task/tree.tsx
+++ b/packages/cli/source/commands/task/tree.tsx
@@ -36,7 +36,7 @@ export default function Tree({ options }: Props) {
 
 				if (rootId) {
 					// Get specific task and its subtree using TaskTree class
-					const rootTree = await taskService.getTaskTreeClass(rootId, maxDepth);
+					const rootTree = await taskService.getTaskTree(rootId, maxDepth);
 					if (!rootTree) {
 						throw new Error(`Task with ID "${rootId}" not found`);
 					}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,12 +20,12 @@ export {
   type TaskTreeData,
   type BatchUpdateOperation,
   type TreeMetrics,
-  validateTaskTree,
 } from './utils/TaskTree.js';
 
 // TaskTree validation
 export {
-  validateTaskTree as validateTaskTreeStructure,
+  validateTaskTree,
+  validateTaskTreeData,
   validateMoveOperation,
   validateTaskForest,
   type ValidationResult,

--- a/packages/core/src/utils/TaskTreeValidation.ts
+++ b/packages/core/src/utils/TaskTreeValidation.ts
@@ -1,4 +1,5 @@
-import type { TaskTree } from './TaskTree.js';
+import type { TaskTree, TaskTreeData } from './TaskTree.js';
+import { taskTreeSchema } from './TaskTree.js';
 
 /**
  * TaskTreeValidation - Utilities for validating tree structure and detecting issues
@@ -348,3 +349,15 @@ const defaultValidationOptions: ValidationOptions = {
   checkStatusConsistency: true,
   allowOrphanedTasks: false,
 };
+
+/**
+ * Validation helper for TaskTreeData schema validation
+ */
+export function validateTaskTreeData(data: unknown): data is TaskTreeData {
+  try {
+    taskTreeSchema.parse(data);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/test/taskService.test.ts
+++ b/packages/core/test/taskService.test.ts
@@ -62,7 +62,7 @@ afterEach(async () => {
 describe('TaskService', () => {
   it('builds a complete task tree', async () => {
     const { A } = (global as any).testTaskIds;
-    const tree = await service.getTaskTreeClass(A);
+    const tree = await service.getTaskTree(A);
     expect(tree).not.toBeNull();
     if (!tree) return;
     expect(tree.task.id).toBe(A);
@@ -79,7 +79,7 @@ describe('TaskService', () => {
 
   it('honours maxDepth when building tree', async () => {
     const { A } = (global as any).testTaskIds;
-    const tree = await service.getTaskTreeClass(A, 1);
+    const tree = await service.getTaskTree(A, 1);
     const children = tree!.getChildren();
     expect(children.length).toBe(2);
     expect(children[0].getChildren().length).toBe(0); // depth limited – grandchildren excluded

--- a/packages/core/test/taskTree.test.ts
+++ b/packages/core/test/taskTree.test.ts
@@ -1,0 +1,302 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { TaskTree, type TaskTreeData } from '../src/utils/TaskTree.js';
+import type { Task } from '../src/schemas/task.js';
+
+describe('TaskTree', () => {
+  const mockTask: Task = {
+    id: 'root',
+    parentId: null,
+    title: 'Root Task',
+    description: 'Root task description',
+    status: 'pending',
+    priority: 'medium',
+    prd: null,
+    contextDigest: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  };
+
+  const mockChild: Task = {
+    id: 'child1',
+    parentId: 'root',
+    title: 'Child Task 1',
+    description: 'Child task description',
+    status: 'pending',
+    priority: 'high',
+    prd: null,
+    contextDigest: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  };
+
+  const mockGrandchild: Task = {
+    id: 'grandchild1',
+    parentId: 'child1',
+    title: 'Grandchild Task 1',
+    description: 'Grandchild task description',
+    status: 'done',
+    priority: 'low',
+    prd: null,
+    contextDigest: null,
+    createdAt: new Date('2024-01-01'),
+    updatedAt: new Date('2024-01-01'),
+  };
+
+  const createTreeData = (): TaskTreeData => ({
+    task: mockTask,
+    children: [
+      {
+        task: mockChild,
+        children: [
+          {
+            task: mockGrandchild,
+            children: [],
+          },
+        ],
+      },
+    ],
+  });
+
+  describe('Construction and Basic Properties', () => {
+    it('creates a TaskTree from TaskTreeData', () => {
+      const data = createTreeData();
+      const tree = new TaskTree(data);
+      
+      expect(tree.task).toEqual(mockTask);
+      expect(tree.id).toBe('root');
+      expect(tree.title).toBe('Root Task');
+    });
+
+    it('provides immutable access to task data', () => {
+      const tree = new TaskTree(createTreeData());
+      const taskRef = tree.task;
+      
+      // Task should have the same data
+      expect(taskRef).toEqual(mockTask);
+      // This may or may not be a reference depending on implementation
+    });
+  });
+
+  describe('Navigation Methods', () => {
+    it('provides access to children', () => {
+      const tree = new TaskTree(createTreeData());
+      const children = tree.getChildren();
+      
+      expect(children).toHaveLength(1);
+      expect(children[0]?.task.id).toBe('child1');
+    });
+
+    it('provides parent access for child nodes', () => {
+      const tree = new TaskTree(createTreeData());
+      const child = tree.getChildren()[0];
+      const parent = child?.getParent();
+      
+      expect(parent?.task.id).toBe('root');
+    });
+
+    it('returns null parent for root node', () => {
+      const tree = new TaskTree(createTreeData());
+      expect(tree.getParent()).toBeNull();
+    });
+
+    it('finds root correctly', () => {
+      const tree = new TaskTree(createTreeData());
+      const grandchild = tree.getChildren()[0]?.getChildren()[0];
+      const root = grandchild?.getRoot();
+      
+      expect(root?.task.id).toBe('root');
+    });
+
+    it('calculates depth correctly', () => {
+      const tree = new TaskTree(createTreeData());
+      const child = tree.getChildren()[0];
+      const grandchild = child?.getChildren()[0];
+      
+      expect(tree.getDepth()).toBe(0);
+      expect(child?.getDepth()).toBe(1);
+      expect(grandchild?.getDepth()).toBe(2);
+    });
+
+    it('gets path from root', () => {
+      const tree = new TaskTree(createTreeData());
+      const grandchild = tree.getChildren()[0]?.getChildren()[0];
+      const path = grandchild?.getPath();
+      
+      expect(path).toHaveLength(3);
+      expect(path?.[0]?.task.id).toBe('root');
+      expect(path?.[1]?.task.id).toBe('child1');
+      expect(path?.[2]?.task.id).toBe('grandchild1');
+    });
+  });
+
+  describe('Traversal Methods', () => {
+    it('walks depth-first correctly', () => {
+      const tree = new TaskTree(createTreeData());
+      const visited: string[] = [];
+      
+      tree.walkDepthFirst((node) => {
+        visited.push(node.task.id);
+      });
+      
+      expect(visited).toEqual(['root', 'child1', 'grandchild1']);
+    });
+
+    it('walks breadth-first correctly', () => {
+      const tree = new TaskTree(createTreeData());
+      const visited: string[] = [];
+      
+      tree.walkBreadthFirst((node) => {
+        visited.push(node.task.id);
+      });
+      
+      expect(visited).toEqual(['root', 'child1', 'grandchild1']);
+    });
+
+    it('finds nodes by predicate', () => {
+      const tree = new TaskTree(createTreeData());
+      const found = tree.find((task) => task.status === 'done');
+      
+      expect(found?.task.id).toBe('grandchild1');
+    });
+
+    it('filters nodes by predicate', () => {
+      const tree = new TaskTree(createTreeData());
+      const filtered = tree.filter((task) => task.status === 'pending');
+      
+      expect(filtered).toHaveLength(2);
+      expect(filtered.map(n => n.task.id)).toEqual(['root', 'child1']);
+    });
+  });
+
+  describe('Immutable Operations', () => {
+    it('updates task immutably', () => {
+      const tree = new TaskTree(createTreeData());
+      const updated = tree.withTask({ status: 'in-progress' });
+      
+      expect(tree.task.status).toBe('pending');
+      expect(updated.task.status).toBe('in-progress');
+      expect(tree).not.toBe(updated);
+    });
+
+    it('updates children immutably', () => {
+      const tree = new TaskTree(createTreeData());
+      const newChildren = tree.getChildren().slice(0, 0); // Empty array
+      const updated = tree.withChildren(newChildren);
+      
+      expect(tree.getChildren()).toHaveLength(1);
+      expect(updated.getChildren()).toHaveLength(0);
+    });
+
+    it('adds child immutably', () => {
+      const tree = new TaskTree(createTreeData());
+      const newChild = TaskTree.fromTask({
+        ...mockChild,
+        id: 'child2',
+        title: 'Child Task 2',
+      });
+      const updated = tree.addChild(newChild);
+      
+      expect(tree.getChildren()).toHaveLength(1);
+      expect(updated.getChildren()).toHaveLength(2);
+    });
+
+    it('removes child immutably', () => {
+      const tree = new TaskTree(createTreeData());
+      const updated = tree.removeChild('child1');
+      
+      expect(tree.getChildren()).toHaveLength(1);
+      expect(updated.getChildren()).toHaveLength(0);
+    });
+  });
+
+  describe('Batch Operations', () => {
+    it('applies batch updates correctly', () => {
+      const tree = new TaskTree(createTreeData());
+      const operations = [
+        { type: 'update_task' as const, taskId: 'root', updates: { status: 'in-progress' as const } },
+        { type: 'bulk_status_update' as const, taskIds: ['child1', 'grandchild1'], status: 'done' as const },
+      ];
+      
+      const updated = tree.batchUpdate(operations);
+      
+      expect(updated.task.status).toBe('in-progress');
+      const child = updated.getChildren()[0];
+      const grandchild = child?.getChildren()[0];
+      expect(child?.task.status).toBe('done');
+      expect(grandchild?.task.status).toBe('done');
+    });
+  });
+
+  describe('Serialization', () => {
+    it('converts to plain object', () => {
+      const tree = new TaskTree(createTreeData());
+      const plain = tree.toPlainObject();
+      
+      expect(plain.task).toEqual(mockTask);
+      expect(plain.children).toHaveLength(1);
+      expect(plain.children[0]?.task).toEqual(mockChild);
+    });
+
+    it('converts to markdown', () => {
+      const tree = new TaskTree(createTreeData());
+      const markdown = tree.toMarkdown();
+      
+      expect(markdown).toContain('- [ ] Root Task');
+      expect(markdown).toContain('- [ ] Child Task 1 (high)');
+      expect(markdown).toContain('- [x] Grandchild Task 1 (low)');
+    });
+  });
+
+  describe('Factory Methods', () => {
+    it('creates tree from task', () => {
+      const tree = TaskTree.fromTask(mockTask);
+      
+      expect(tree.task).toEqual(mockTask);
+      expect(tree.getChildren()).toHaveLength(0);
+    });
+
+    it('creates tree from task with children', () => {
+      const childTree = TaskTree.fromTask(mockChild);
+      const tree = TaskTree.fromTask(mockTask, [childTree]);
+      
+      expect(tree.getChildren()).toHaveLength(1);
+      expect(tree.getChildren()[0]?.task.id).toBe('child1');
+    });
+  });
+
+  describe('Tree Metrics', () => {
+    it('calculates descendant count', () => {
+      const tree = new TaskTree(createTreeData());
+      
+      expect(tree.getDescendantCount()).toBe(2); // child1 + grandchild1
+    });
+
+    it('checks ancestry relationships', () => {
+      const tree = new TaskTree(createTreeData());
+      const child = tree.getChildren()[0];
+      const grandchild = child?.getChildren()[0];
+      
+      expect(tree.isAncestorOf(child!)).toBe(true);
+      expect(tree.isAncestorOf(grandchild!)).toBe(true);
+      expect(child?.isAncestorOf(grandchild!)).toBe(true);
+      expect(grandchild?.isAncestorOf(tree)).toBe(false);
+    });
+
+    it('aggregates metrics across multiple trees', () => {
+      const tree1 = new TaskTree(createTreeData());
+      const tree2 = TaskTree.fromTask({
+        ...mockTask,
+        id: 'root2',
+        title: 'Root Task 2',
+      });
+      
+      const metrics = TaskTree.aggregateMetrics([tree1, tree2]);
+      
+      expect(metrics.totalTasks).toBe(4); // 3 from tree1 + 1 from tree2
+      expect(metrics.treeCount).toBe(2);
+      expect(metrics.maxDepth).toBe(2); // tree1 has depth 2
+      expect(metrics.statusDistribution.pending).toBe(3);
+      expect(metrics.statusDistribution.done).toBe(1);
+    });
+  });
+});

--- a/packages/core/test/taskTreeEnhanced.test.ts
+++ b/packages/core/test/taskTreeEnhanced.test.ts
@@ -44,18 +44,18 @@ describe('TaskTree Enhanced Features', () => {
       
       const operations: BatchUpdateOperation[] = [
         { 
-          type: 'update_by_predicate', 
-          predicate: (task) => task.status === 'pending',
-          updates: { status: 'in-progress' }
+          type: 'bulk_status_update', 
+          taskIds: ['1', '2'], // Root and child1 IDs
+          status: 'in-progress'
         }
       ];
       
       const result = tree.batchUpdate(operations);
-      expect(result.task.status).toBe('in-progress'); // Root was pending
+      expect(result.task.status).toBe('in-progress'); // Root was updated
       
       const children = result.getChildren();
-      expect(children[0].task.status).toBe('in-progress'); // Child1 was pending
-      expect(children[1].task.status).toBe('done'); // Child2 was already done
+      expect(children[0].task.status).toBe('in-progress'); // Child1 was updated
+      expect(children[1].task.status).toBe('done'); // Child2 was unchanged
     });
 
     it('applies bulk status updates', () => {
@@ -150,7 +150,7 @@ describe('TaskTree Enhanced Features', () => {
       expect(metrics.totalTasks).toBe(4);
       expect(metrics.treeCount).toBe(2);
       expect(metrics.maxDepth).toBe(2); // Root1 -> Child1 -> Grandchild1
-      expect(metrics.averageDepth).toBe(1); // (0 + 1 + 2 + 0) / 4 = 0.75
+      expect(metrics.averageDepth).toBe(0.75); // (0 + 1 + 2 + 0) / 4 = 0.75
       
       // Status distribution
       expect(metrics.statusDistribution).toEqual({

--- a/packages/mcp/test/task-handlers.test.ts
+++ b/packages/mcp/test/task-handlers.test.ts
@@ -19,8 +19,7 @@ const mockStore = {
 };
 
 const mockTaskService = {
-  getTaskTree: vi.fn(), // Legacy method - deprecated 
-  getTaskTreeClass: vi.fn(),
+  getTaskTree: vi.fn(),
   getTaskTrees: vi.fn(),
   getTaskWithContext: vi.fn(),
   getTaskAncestors: vi.fn(),


### PR DESCRIPTION
Implements comprehensive TaskTree cleanup and simplification from issue #10.

## Summary
- Remove legacy code and deprecated methods for cleaner API
- Simplify batch operations to focus on core use cases
- Consolidate validation exports and fix duplications
- Add comprehensive test coverage for TaskTree functionality
- Standardize method naming across all components

## Changes Made

### Legacy Code Removal
- Removed duplicate `LegacyTaskTree` interface from TaskService
- Eliminated deprecated `getTaskTree()` method (legacy format)
- Removed `toLegacyFormat()` and `fromLegacyFormat()` conversion methods
- Cleaned up legacy `LegacyTaskTree` interface from TaskTree.ts

### API Simplification
- Renamed `getTaskTreeClass()` → `getTaskTree()` for consistency
- Updated all references in MCP handlers, CLI, and test files
- Simplified `BatchUpdateOperation` from 5 complex types to 2 core use cases
- Consolidated duplicate `validateTaskTree` exports in index.ts

### Test Coverage
- Added comprehensive `taskTree.test.ts` covering navigation, traversal, serialization
- Fixed test expectations to match actual implementation behavior
- Updated existing tests to use simplified batch operations
- Added `validateTaskTreeData` helper for schema validation

## Benefits
- **Cleaner API**: Single `getTaskTree()` method instead of confusing variants
- **Simpler Operations**: Focused batch operations for common use cases
- **Better Testing**: Comprehensive test suite covering core functionality
- **Maintainability**: Eliminated duplicate code and legacy cruft
- **Type Safety**: Consistent TypeScript coverage throughout

🤖 Generated with [Claude Code](https://claude.ai/code)