### PR TITLE
Clean up task ID generation

### DIFF
--- a/packages/core/test/taskId.test.ts
+++ b/packages/core/test/taskId.test.ts
@@ -1,48 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
-  numberToLetters,
-  lettersToNumber,
   parseTaskId,
   validateTaskId,
   validateSubtaskId,
 } from '../src/utils/taskId.js';
 
 describe('Task ID Utilities', () => {
-  describe('numberToLetters', () => {
-    it('should convert numbers to letters correctly', () => {
-      expect(numberToLetters(0)).toBe('A');
-      expect(numberToLetters(1)).toBe('B');
-      expect(numberToLetters(25)).toBe('Z');
-      expect(numberToLetters(26)).toBe('AA');
-      expect(numberToLetters(27)).toBe('AB');
-      expect(numberToLetters(51)).toBe('AZ');
-      expect(numberToLetters(52)).toBe('BA');
-      expect(numberToLetters(701)).toBe('ZZ');
-      expect(numberToLetters(702)).toBe('AAA');
-    });
-  });
-
-  describe('lettersToNumber', () => {
-    it('should convert letters to numbers correctly', () => {
-      expect(lettersToNumber('A')).toBe(0);
-      expect(lettersToNumber('B')).toBe(1);
-      expect(lettersToNumber('Z')).toBe(25);
-      expect(lettersToNumber('AA')).toBe(26);
-      expect(lettersToNumber('AB')).toBe(27);
-      expect(lettersToNumber('AZ')).toBe(51);
-      expect(lettersToNumber('BA')).toBe(52);
-      expect(lettersToNumber('ZZ')).toBe(701);
-      expect(lettersToNumber('AAA')).toBe(702);
-    });
-
-    it('should be inverse of numberToLetters', () => {
-      const testNumbers = [0, 1, 25, 26, 27, 51, 52, 100, 701, 702];
-      testNumbers.forEach(num => {
-        expect(lettersToNumber(numberToLetters(num))).toBe(num);
-      });
-    });
-  });
-
   describe('parseTaskId', () => {
     it('should parse root task IDs correctly', () => {
       const parsed = parseTaskId('A');


### PR DESCRIPTION
Fixes #13

Cleans up the task ID generation code by removing the sequential number fallback and simplifying the implementation.

## Changes
- Remove sequential number fallback in favor of proper error handling
- Add TaskIdGenerationError for consistent error reporting
- Simplify code by removing unused number-to-letter conversion utilities
- Consolidate random letter generation into single function
- Update tests to remove coverage for deleted utilities
- Prefer failure over inconsistency as requested

## Testing
- All existing tests pass
- Type checking passes
- Linting passes

Generated with [Claude Code](https://claude.ai/code)