### PR TITLE
feat: increase biome cognitive complexity threshold to 25

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -28,7 +28,12 @@
 		"rules": {
 			"recommended": true,
 			"complexity": {
-				"noExcessiveCognitiveComplexity": "error"
+				"noExcessiveCognitiveComplexity": {
+					"level": "error",
+					"options": {
+						"maxAllowedComplexity": 25
+					}
+				}
 			},
 			"correctness": {
 				"noUnusedImports": "error",


### PR DESCRIPTION
Allow higher function complexity by setting maxAllowedComplexity to 25 in the noExcessiveCognitiveComplexity rule. This provides more flexibility for complex business logic while still maintaining code quality standards.

Closes #31

Generated with [Claude Code](https://claude.ai/code)