### PR TITLE
feat: add task ordering and `next` command functionality

### DIFF
--- a/packages/cli/source/commands/task/next.tsx
+++ b/packages/cli/source/commands/task/next.tsx
@@ -1,0 +1,124 @@
+import type { Task } from "@astrolabe/core";
+import { Box, Text } from "ink";
+import { useEffect, useState } from "react";
+import { useTaskService } from "../../context/DatabaseContext.js";
+
+export const description =
+	"Get the next task to work on (highest priority task with no incomplete dependencies)";
+
+export default function Next() {
+	const taskService = useTaskService();
+	const [task, setTask] = useState<Task | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		async function loadNextTask() {
+			try {
+				const nextTask = await taskService.getNextTask();
+				setTask(nextTask);
+			} catch (err) {
+				setError(
+					err instanceof Error ? err.message : "Failed to load next task",
+				);
+			} finally {
+				setLoading(false);
+			}
+		}
+		loadNextTask();
+	}, [taskService]);
+
+	if (loading) return <Text>Finding your next task...</Text>;
+	if (error) return <Text color="red">Error: {error}</Text>;
+
+	const getStatusColor = (status: string) => {
+		switch (status) {
+			case "done":
+				return "green";
+			case "in-progress":
+				return "yellow";
+			case "pending":
+				return "gray";
+			default:
+				return "white";
+		}
+	};
+
+	const getPriorityColor = (priority: string) => {
+		switch (priority) {
+			case "high":
+				return "red";
+			case "medium":
+				return "yellow";
+			case "low":
+				return "blue";
+			default:
+				return "white";
+		}
+	};
+
+	if (!task) {
+		return (
+			<Box flexDirection="column">
+				<Text bold color="green">
+					🎉 No tasks available!
+				</Text>
+				<Text color="gray">
+					All your pending tasks have incomplete dependencies or there are no
+					pending tasks.
+				</Text>
+				<Text color="gray">
+					Use <Text color="cyan">astrolabe task available</Text> to see all
+					tasks that could be started.
+				</Text>
+			</Box>
+		);
+	}
+
+	return (
+		<Box flexDirection="column">
+			<Text bold>📋 Next Task</Text>
+			<Text color="gray">
+				Based on priority and dependencies, here's your next task:
+			</Text>
+
+			<Box flexDirection="column" marginTop={1} padding={1} borderStyle="round">
+				<Text>
+					<Text color="cyan">{task.id}</Text>
+				</Text>
+				<Text bold>{task.title}</Text>
+
+				<Box marginTop={1}>
+					<Text>
+						Status:{" "}
+						<Text color={getStatusColor(task.status)}>{task.status}</Text>
+						{" | "}
+						Priority:{" "}
+						<Text color={getPriorityColor(task.priority)}>{task.priority}</Text>
+					</Text>
+				</Box>
+
+				{task.description && (
+					<Box marginTop={1}>
+						<Text color="gray">{task.description}</Text>
+					</Box>
+				)}
+
+				<Box marginTop={1}>
+					<Text color="gray">
+						Created: {task.createdAt.toLocaleDateString()}
+					</Text>
+				</Box>
+			</Box>
+
+			<Box marginTop={1}>
+				<Text color="green">
+					💡 Ready to start? Use{" "}
+					<Text color="cyan">
+						astrolabe task update {task.id} --status in-progress
+					</Text>
+				</Text>
+			</Box>
+		</Box>
+	);
+}

--- a/packages/core/test/getNextTask.test.ts
+++ b/packages/core/test/getNextTask.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, afterEach } from 'vitest';
+import { createDatabase } from '../src/database/index.js';
+import { TaskService } from '../src/services/TaskService.js';
+import type { Task } from '../src/schemas/task.js';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { rmSync, existsSync } from 'node:fs';
+import type { Store } from '../src/database/store.js';
+
+describe('TaskService.getNextTask', () => {
+  let taskService: TaskService;
+  let store: Store;
+  let dbPath: string;
+  let task1: Task, task2: Task, task3: Task;
+
+  beforeEach(async () => {
+    // Use a unique file in temporary directory for each test run
+    dbPath = join(tmpdir(), `getNextTask-test-${Date.now()}.db`);
+    store = await createDatabase({ dbPath, verbose: false });
+    taskService = new TaskService(store);
+
+    // Create test tasks with different priorities
+    task1 = await store.addTask({
+      title: 'Low priority task',
+      priority: 'low',
+      status: 'pending',
+    });
+
+    task2 = await store.addTask({
+      title: 'High priority task',
+      priority: 'high',
+      status: 'pending',
+    });
+
+    task3 = await store.addTask({
+      title: 'Medium priority task',
+      priority: 'medium',
+      status: 'pending',
+    });
+  });
+
+  afterEach(async () => {
+    // Clean up the temporary database file
+    if (existsSync(dbPath)) {
+      rmSync(dbPath, { recursive: true, force: true });
+    }
+  });
+
+  it('should return highest priority task', async () => {
+    const nextTask = await taskService.getNextTask();
+    
+    expect(nextTask).not.toBeNull();
+    expect(nextTask?.id).toBe(task2.id); // High priority task
+    expect(nextTask?.priority).toBe('high');
+  });
+
+  it('should return null when no pending tasks available', async () => {
+    // Mark all tasks as done
+    await store.updateTask(task1.id, { status: 'done' });
+    await store.updateTask(task2.id, { status: 'done' });
+    await store.updateTask(task3.id, { status: 'done' });
+
+    const nextTask = await taskService.getNextTask();
+    expect(nextTask).toBeNull();
+  });
+
+  it('should prioritize by priority then by creation date', async () => {
+    // Mark the high priority task as done, so medium should be next
+    await store.updateTask(task2.id, { status: 'done' });
+
+    const nextTask = await taskService.getNextTask();
+    
+    expect(nextTask).not.toBeNull();
+    expect(nextTask?.priority).toBe('medium'); // Next highest available priority
+    expect(nextTask?.id).toBe(task3.id);
+  });
+
+  it('should not return tasks that are blocked by dependencies', async () => {
+    // Add a dependency: task2 depends on task1
+    await taskService.addTaskDependency(task2.id, task1.id);
+
+    const nextTask = await taskService.getNextTask();
+    
+    // Should return task3 (medium) or task1 (low), not task2 (high) which is blocked
+    expect(nextTask).not.toBeNull();
+    expect(nextTask?.id).not.toBe(task2.id);
+  });
+});

--- a/packages/mcp/src/handlers/TaskHandlers.ts
+++ b/packages/mcp/src/handlers/TaskHandlers.ts
@@ -193,4 +193,8 @@ export class TaskHandlers {
 
     return context;
   }
+
+  async getNextTask(): Promise<Task | null> {
+    return await this.context.taskService.getNextTask();
+  }
 }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -107,6 +107,13 @@ async function main() {
     })
   );
 
+  server.tool('getNextTask',
+    {},
+    wrapMCPHandler(async () => {
+      return taskHandlers.getNextTask();
+    })
+  );
+
   // Register dependency management tools
   server.tool('addTaskDependency',
     addTaskDependencySchema.shape,


### PR DESCRIPTION
Implements task ordering algorithm and `next` command functionality as requested in issue #29.

## Changes:
- Add TaskService.getNextTask() method with priority-based ordering
- Add CLI command `astrolabe task next` with interactive UI
- Add MCP command `getNextTask` for external agent integration
- Include comprehensive test coverage
- Follow existing code conventions and type safety

## Algorithm:
Uses dependency graph to find open tasks with no incomplete dependencies, then sorts by priority (high → medium → low) and creation date (oldest first).

Closes #29

Generated with [Claude Code](https://claude.ai/code)