### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Astrotask keeps workstreams organised and agent‑ready:
 
 ```bash
 # Until v1.0 install the latest pre‑release tag
-npm install -g @astrotask/cli@next      # or: pnpm / yarn
+npm install -g @astrotask/cli@latest      # or: pnpm / yarn
 ```
 
 Upgrading is just as easy:


### PR DESCRIPTION
```
❯ npm install -g @astrotask/cli@next
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @astrotask/cli@next.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
```